### PR TITLE
add husky

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,3 @@
+pnpm run lint
+pnpm run format
+pnpm run build

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "tsc -p .",
     "lint": "eslint '**/*.{ts,yaml,yml}'",
     "test": "jest",
+    "husky": "husky",
     "format": "prettier --write '**/**/*.{js,ts,tsx,css}'",
     "format:check": "prettier --check '**/**/*.{ts,tsx,js,jsx,css}'"
   },
@@ -20,6 +21,7 @@
     "eslint": "^9.20.0",
     "eslint-plugin-react": "^7.37.4",
     "globals": "^15.14.0",
+    "husky": "^9.1.7",
     "prettier": "^3.5.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.7.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ devDependencies:
   globals:
     specifier: ^15.14.0
     version: 15.14.0
+  husky:
+    specifier: ^9.1.7
+    version: 9.1.7
   prettier:
     specifier: ^3.5.0
     version: 3.5.0
@@ -1087,6 +1090,12 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       function-bind: 1.1.2
+    dev: true
+
+  /husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
+    hasBin: true
     dev: true
 
   /ignore@5.3.2:


### PR DESCRIPTION
This pull request introduces Husky for managing Git hooks and updates the project configuration to include linting, formatting, and building steps in the pre-commit hook. The most important changes include adding Husky to the project dependencies and configuration files, and updating the `pnpm-lock.yaml` to reflect these additions.

### Adding Husky for Git hooks management:

* [`.husky/pre-commit`](diffhunk://#diff-d2bc4bbf14eadc292d84e0ef5f7a93115c23557f533809fc80b896934291529dR1-R3): Added commands to run lint, format, and build tasks before committing.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R12): Added Husky to the `scripts` section to manage Git hooks.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R24): Included Husky as a dependency.
* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR20-R22): Updated to include Husky in the `devDependencies` section.
* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1095-R1100): Added Husky package details under the `packages` section.